### PR TITLE
Add Spring Boot app setup instructions to README

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,10 +1,5 @@
 # Getting Started
 
-### Run API locally
-
-Using your IDE, execute `MainApplication::main`.
-
-If you are using VSCode, you can just press `F5` from anywhere to start debugging.
 
 ### Reference Documentation
 For further reference, please consider the following guides:

--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ Run tests
 mvn test
 ```
 
+### Run API locally
+
+Using your IDE, execute `MainApplication::main`.
+
+If you are using VSCode, you can just press `F5` from anywhere to start debugging.


### PR DESCRIPTION
Added in the README.md file instructions to build, run, and test the Spring Boot app.


Closes #24