### PR TITLE
refactor: replace Team-Edition ManyToMany with ManyToOne relationship

### DIFF
--- a/src/main/java/cat/udl/eps/softarch/fll/domain/Edition.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/domain/Edition.java
@@ -7,17 +7,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Data
@@ -46,14 +44,10 @@ public class Edition extends UriEntity<Long> {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	private EditionState state = EditionState.DRAFT;
 
-	@ManyToMany
-	@JoinTable(
-		name = "edition_teams",
-		joinColumns = @JoinColumn(name = "edition_id"),
-		inverseJoinColumns = @JoinColumn(name = "team_name"))
+	@OneToMany(mappedBy = "edition")
 	@ToString.Exclude
 	@EqualsAndHashCode.Exclude
-	private Set<Team> teams = new HashSet<>();
+	private List<Team> teams = new ArrayList<>();
 
 	protected Edition() {
 	}

--- a/src/main/java/cat/udl/eps/softarch/fll/domain/Team.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/domain/Team.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import cat.udl.eps.softarch.fll.domain.volunteer.Floater;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -14,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
@@ -62,14 +62,9 @@ public class Team extends UriEntity<String> {
 	@Size(max = 10, message = "A team cannot have more than 10 members")
 	@ToString.Exclude
 	private List<TeamMember> members = new ArrayList<>();
-	@ManyToMany
-	@JoinTable(
-		name = "edition_teams",
-		joinColumns = @JoinColumn(name = "team_name"),
-		inverseJoinColumns = @JoinColumn(name = "edition_id"))
-	@JsonIdentityReference(alwaysAsId = true)
-	@ToString.Exclude
-	private Set<Edition> registeredEditions = new HashSet<>();
+	@ManyToOne
+	@JoinColumn(name = "edition_id")
+	private Edition edition;
 	@ManyToMany
 	@JoinTable(
 		name = "team_coach",
@@ -139,12 +134,6 @@ public class Team extends UriEntity<String> {
 		}
 		floaters.remove(floater);
 		floater.getAssistedTeams().remove(this);
-	}
-
-	public void registerEdition(Edition edition) {
-		if (edition != null) {
-			registeredEditions.add(edition);
-		}
 	}
 
 	public void addCoach(Coach coach) {

--- a/src/main/java/cat/udl/eps/softarch/fll/handler/EditionTeamRegistrationExceptionHandler.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/handler/EditionTeamRegistrationExceptionHandler.java
@@ -23,7 +23,7 @@ public class EditionTeamRegistrationExceptionHandler {
 	private HttpStatus resolveStatus(String error) {
 		return switch (error) {
 			case "EDITION_NOT_FOUND", "TEAM_NOT_FOUND" -> HttpStatus.NOT_FOUND;
-			case "MAX_TEAMS_REACHED", "TEAM_ALREADY_REGISTERED" -> HttpStatus.CONFLICT;
+			case "MAX_TEAMS_REACHED", "TEAM_ALREADY_REGISTERED", "TEAM_ALREADY_IN_ANOTHER_EDITION" -> HttpStatus.CONFLICT;
 			case "EDITION_OPERATION_NOT_ALLOWED" -> HttpStatus.UNPROCESSABLE_CONTENT;
 			default -> HttpStatus.BAD_REQUEST;
 		};

--- a/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
@@ -67,7 +67,7 @@ public class ScientificProjectEventHandler {
 			return;
 		}
 
-		if (!teamRepository.existsByIdAndRegisteredEditionsId(project.getTeam().getId(), project.getEdition().getId())) {
+		if (!teamRepository.existsByIdAndEditionId(project.getTeam().getId(), project.getEdition().getId())) {
 			throw new DomainValidationException("EDITION_TEAM_MISMATCH",
 					"The referenced team is not registered in the referenced edition");
 		}

--- a/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
@@ -67,7 +67,12 @@ public class ScientificProjectEventHandler {
 			return;
 		}
 
-		if (!teamRepository.existsByIdAndEditionId(project.getTeam().getId(), project.getEdition().getId())) {
+		boolean registered = teamRepository.findById(project.getTeam().getId())
+				.map(team -> team.getEdition() != null
+						&& team.getEdition().getId().equals(project.getEdition().getId()))
+				.orElse(false);
+
+		if (!registered) {
 			throw new DomainValidationException("EDITION_TEAM_MISMATCH",
 					"The referenced team is not registered in the referenced edition");
 		}

--- a/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/handler/ScientificProjectEventHandler.java
@@ -4,6 +4,7 @@ import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
 import org.springframework.data.rest.core.annotation.HandleBeforeSave;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
 import org.springframework.stereotype.Component;
+import java.util.Objects;
 import cat.udl.eps.softarch.fll.domain.ScientificProject;
 import cat.udl.eps.softarch.fll.exception.DomainValidationException;
 import cat.udl.eps.softarch.fll.repository.edition.EditionRepository;
@@ -69,7 +70,7 @@ public class ScientificProjectEventHandler {
 
 		boolean registered = teamRepository.findById(project.getTeam().getId())
 				.map(team -> team.getEdition() != null
-						&& team.getEdition().getId().equals(project.getEdition().getId()))
+						&& Objects.equals(team.getEdition().getId(), project.getEdition().getId()))
 				.orElse(false);
 
 		if (!registered) {

--- a/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
@@ -2,12 +2,10 @@ package cat.udl.eps.softarch.fll.repository.team;
 
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
-import org.springframework.data.rest.core.annotation.RestResource;
 import cat.udl.eps.softarch.fll.domain.Team;
 
 @RepositoryRestResource(path = "teams")
@@ -25,10 +23,6 @@ public interface TeamRepository extends CrudRepository<Team, String>, PagingAndS
 
 	Optional<Team> findByName(@Param("name") String name);
 
-	@RestResource(exported = false)
-	boolean existsByIdAndRegisteredEditionsId(String teamName, Long editionId);
+	boolean existsByIdAndEditionId(String teamName, Long editionId);
 
-	@RestResource(exported = false)
-	@Query("select distinct t from Team t left join fetch t.registeredEditions where t.name = :name")
-	Optional<Team> findByNameWithRegisteredEditions(@Param("name") String name);
 }

--- a/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
@@ -23,6 +23,4 @@ public interface TeamRepository extends CrudRepository<Team, String>, PagingAndS
 
 	Optional<Team> findByName(@Param("name") String name);
 
-	boolean existsByIdAndEditionId(String teamName, Long editionId);
-
 }

--- a/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/repository/team/TeamRepository.java
@@ -2,10 +2,14 @@ package cat.udl.eps.softarch.fll.repository.team;
 
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 import cat.udl.eps.softarch.fll.domain.Team;
 
 @RepositoryRestResource(path = "teams")
@@ -22,5 +26,10 @@ public interface TeamRepository extends CrudRepository<Team, String>, PagingAndS
 	List<Team> findByMembersRole(@Param("role") String role);
 
 	Optional<Team> findByName(@Param("name") String name);
+
+	@RestResource(exported = false)
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select t from Team t where t.name = :name")
+	Optional<Team> findByNameForUpdate(@Param("name") String name);
 
 }

--- a/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
@@ -52,7 +52,8 @@ public class EditionTeamRegistrationService {
 					"Edition " + editionId + " has reached the maximum of " + Edition.MAX_TEAMS + " teams");
 		}
 
-		edition.getTeams().add(team);
-		return editionRepository.save(edition);
+		team.setEdition(edition);
+		teamRepository.save(team);
+		return edition;
 	}
 }

--- a/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
@@ -41,6 +41,12 @@ public class EditionTeamRegistrationService {
 				.orElseThrow(() -> new EditionTeamRegistrationException(
 						"TEAM_NOT_FOUND", "Team with id " + teamId + " not found"));
 
+		if (team.getEdition() != null && !team.getEdition().getId().equals(editionId)) {
+			throw new EditionTeamRegistrationException(
+					"TEAM_ALREADY_IN_ANOTHER_EDITION",
+					"Team " + teamId + " is already registered in another edition");
+		}
+
 		if (edition.containsTeam(team)) {
 			throw new EditionTeamRegistrationException(
 					"TEAM_ALREADY_REGISTERED", "Team " + teamId + " is already registered in edition " + editionId);

--- a/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
@@ -54,6 +54,7 @@ public class EditionTeamRegistrationService {
 
 		team.setEdition(edition);
 		teamRepository.save(team);
+		edition.getTeams().add(team);
 		return edition;
 	}
 }

--- a/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/service/edition/EditionTeamRegistrationService.java
@@ -37,7 +37,7 @@ public class EditionTeamRegistrationService {
 			throw new EditionTeamRegistrationException(exception.getError(), exception.getMessage(), exception);
 		}
 
-		Team team = teamRepository.findById(teamId)
+		Team team = teamRepository.findByNameForUpdate(teamId)
 				.orElseThrow(() -> new EditionTeamRegistrationException(
 						"TEAM_NOT_FOUND", "Team with id " + teamId + " not found"));
 

--- a/src/test/java/cat/udl/eps/softarch/fll/steps/edition/ManageScientificProjectStepDefs.java
+++ b/src/test/java/cat/udl/eps/softarch/fll/steps/edition/ManageScientificProjectStepDefs.java
@@ -134,12 +134,12 @@ public class ManageScientificProjectStepDefs {
 		String teamName = extractTeamName(teamUri);
 		Long editionId = extractEditionId(editionUri);
 
-		Team team = teamRepository.findByNameWithRegisteredEditions(teamName)
+		Team team = teamRepository.findById(teamName)
 				.orElseThrow(() -> new IllegalStateException("Missing team in test setup: " + teamName));
 		Edition edition = editionRepository.findById(editionId)
 				.orElseThrow(() -> new IllegalStateException("Missing edition in test setup: " + editionId));
 
-		team.registerEdition(edition);
+		team.setEdition(edition);
 		teamRepository.save(team);
 	}
 

--- a/src/test/java/cat/udl/eps/softarch/fll/steps/team/TeamEditionRegistrationStepDefs.java
+++ b/src/test/java/cat/udl/eps/softarch/fll/steps/team/TeamEditionRegistrationStepDefs.java
@@ -62,8 +62,8 @@ public class TeamEditionRegistrationStepDefs {
 	public void teamIsAlreadyRegistered(String teamName) {
 		Edition edition = editionRepository.findById(currentEditionId()).orElseThrow();
 		Team team = teamRepository.findById(teamName).orElseThrow();
-		edition.getTeams().add(team);
-		editionRepository.save(edition);
+		team.setEdition(edition);
+		teamRepository.save(team);
 	}
 
 	@Given("The current edition already has {int} teams registered")
@@ -76,9 +76,9 @@ public class TeamEditionRegistrationStepDefs {
 				Team created = Team.create(teamName, "Igualada", 2000, "Challenge");
 				return teamRepository.save(created);
 			});
-			edition.getTeams().add(team);
+			team.setEdition(edition);
+			teamRepository.save(team);
 		});
-		editionRepository.save(edition);
 	}
 
 	@Given("The current edition is in state {string}")


### PR DESCRIPTION
Closes #139

Replaces the ManyToMany join table between Team and Edition with a
direct ManyToOne FK (edition_id on team). A team now belongs to at
most one edition at a time