### PR TITLE
feat: associate ScientificProject with ProjectRoom

### DIFF
--- a/src/main/java/cat/udl/eps/softarch/fll/config/RepositoryRestConfig.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/config/RepositoryRestConfig.java
@@ -1,0 +1,16 @@
+package cat.udl.eps.softarch.fll.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import cat.udl.eps.softarch.fll.domain.ProjectRoom;
+
+@Configuration
+public class RepositoryRestConfig implements RepositoryRestConfigurer {
+
+    @Override
+    public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors) {
+        config.exposeIdsFor(ProjectRoom.class);
+    }
+}

--- a/src/main/java/cat/udl/eps/softarch/fll/domain/ScientificProject.java
+++ b/src/main/java/cat/udl/eps/softarch/fll/domain/ScientificProject.java
@@ -38,6 +38,10 @@ public class ScientificProject extends UriEntity<Long> {
 	@JsonIdentityReference(alwaysAsId = true)
 	private Edition edition;
 
+	@ManyToOne
+	@JoinColumn(name = "project_room_id")
+	private ProjectRoom projectRoom;
+
 	public static ScientificProject create(Integer score) {
 		DomainValidation.requireNonNegative(score, "score");
 


### PR DESCRIPTION
Add @ManyToOne ProjectRoom field to ScientificProject so Spring Data REST exposes GET/PUT /scientificProjects/{id}/projectRoom endpoints and the projectRoom HAL link. Also configure exposeIdsFor(ProjectRoom) so roomNumber is included in the response body.
Closes #50 